### PR TITLE
Updated fuji docs value

### DIFF
--- a/tooling.json
+++ b/tooling.json
@@ -167,7 +167,7 @@
             }
             },
             "F-UJI": {
-                "docs": "https://github.com/pangaea-data-publisher/fuji/blob/master/README.md",
+                "docs": "QC.FAIR/fuji.py",
                 "docker": {
                     "image": "steinsteiny/fuji:latest",
                     "oneshot": false,


### PR DESCRIPTION
Last diff between FUJI and EVA.
Hopefully docker can find fuji.py file now?
`exec failed: container_linux.go:380: starting container process caused: exec: "fuji.py": executable file not found in $PATH: unknown`